### PR TITLE
Configure Sanctum for SPA auth

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -14,6 +14,7 @@ return Application::configure(basePath: dirname(__DIR__))
     ->withMiddleware(function (Middleware $middleware): void {
         $middleware->group('api', [
             \App\Http\Middleware\LogApiRequests::class,
+            \Laravel\Sanctum\Http\Middleware\EnsureFrontendRequestsAreStateful::class,
         ]);
     })
     ->withExceptions(function (Exceptions $exceptions): void {

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -12,7 +12,7 @@
     "php": "^8.2",
     "darkaonline/l5-swagger": "dev-master",
     "laravel/framework": "^12.0",
-    "laravel/sanctum": "^4.0",
+    "laravel/sanctum": "^4.1",
     "laravel/tinker": "^2.10.1",
     "spatie/laravel-query-builder": "^6.0"
   },

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1b7acc308126bb6359eb9b1f6c7ea2cf",
+    "content-hash": "79ad2ea9a57edd06b2e1a4b10dbe3c6a",
     "packages": [
         {
             "name": "brick/math",

--- a/backend/config/sanctum.php
+++ b/backend/config/sanctum.php
@@ -1,7 +1,7 @@
 <?php
 
 return [
-    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost,127.0.0.1')), 
+    'stateful' => explode(',', env('SANCTUM_STATEFUL_DOMAINS', 'localhost:5173')),
     'guard' => ['web'],
     'expiration' => null,
     'middleware' => [


### PR DESCRIPTION
## Summary
- require Laravel Sanctum
- set Sanctum stateful domains default to `localhost:5173`
- add `EnsureFrontendRequestsAreStateful` to API middleware group

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68795e80ad108322aeb058e771f86e80