### PR TITLE
Implement basic auth controller for API

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+
+class AuthController extends Controller
+{
+    public function login(Request $request): JsonResponse
+    {
+        $credentials = $request->validate([
+            'email' => 'required|email',
+            'password' => 'required',
+        ]);
+
+        if (!Auth::attempt($credentials)) {
+            return response()->json(['message' => 'Unauthorized'], 401);
+        }
+
+        $user = Auth::user();
+        $token = $user->createToken('auth-token')->plainTextToken;
+
+        return response()->json([
+            'token' => $token,
+            'user' => $user,
+        ]);
+    }
+
+    public function logout(Request $request): JsonResponse
+    {
+        $request->user()->currentAccessToken()->delete();
+
+        return response()->json(['message' => 'Logged out']);
+    }
+
+    public function user(Request $request): JsonResponse
+    {
+        return response()->json(['user' => $request->user()]);
+    }
+}

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -2,7 +2,14 @@
 
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\AuthController;
 
 Route::get('/ping', function () {
     return response()->json(['message' => 'pong']);
+});
+
+Route::post('/login', [AuthController::class, 'login']);
+Route::middleware('auth:sanctum')->group(function () {
+    Route::post('/logout', [AuthController::class, 'logout']);
+    Route::get('/user', [AuthController::class, 'user']);
 });


### PR DESCRIPTION
## Summary
- add `AuthController` with login/logout/user endpoints
- register new auth routes in `routes/api.php`

## Testing
- `composer install --no-interaction --no-progress`
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_68795fc2cf0c83228e772940e80426b1