### PR TITLE
Update login page with forgot-password route

### DIFF
--- a/frontend/src/pages/ForgotPassword.vue
+++ b/frontend/src/pages/ForgotPassword.vue
@@ -1,0 +1,17 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-muted">
+    <form class="rounded-xl border bg-card text-card-foreground shadow p-8 max-w-md mx-auto space-y-6">
+      <div class="space-y-2 text-center">
+        <h3 class="text-2xl font-semibold tracking-tight">Forgot password</h3>
+        <p class="text-sm text-muted-foreground">Enter your email to reset your password</p>
+      </div>
+      <Input placeholder="m@example.com" type="email" />
+      <Button class="w-full">Send reset link</Button>
+    </form>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+</script>

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -10,7 +10,7 @@
           Enter your email below to create your account
         </p>
       </div>
-      <Button variant="outline" class="w-full">
+      <Button variant="outline" class="w-full" @click="googleLogin">
         <span class="mr-2">G</span>
         Google
       </Button>
@@ -24,7 +24,14 @@
       </div>
       <Input v-model="email" placeholder="m@example.com" type="email" />
       <Input v-model="password" placeholder="Password" type="password" />
+      <div class="text-right">
+        <a href="/forgot-password" class="text-xs text-muted-foreground hover:underline">Forgot password?</a>
+      </div>
       <Button type="submit" class="w-full">Create account</Button>
+      <p class="text-sm text-center text-muted-foreground">
+        Already have an account?
+        <a href="/login" class="underline hover:text-primary">Log in</a>
+      </p>
     </form>
   </div>
 </template>
@@ -49,7 +56,11 @@ const login = async () => {
     userStore.setUser(data.user)
     router.push('/')
   } catch (e) {
-    alert('Невірний email або пароль')
+    alert('Wrong credentials')
   }
+}
+
+const googleLogin = () => {
+  window.location.href = '/auth/google'
 }
 </script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,10 +1,12 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import DemoPage from '@/components/DemoPage.vue'
 import Login from '@/pages/Login.vue'
+import ForgotPassword from '@/pages/ForgotPassword.vue'
 
 const routes = [
   { path: '/', component: DemoPage },
   { path: '/login', component: Login },
+  { path: '/forgot-password', component: ForgotPassword },
 ]
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- add Google login action
- show 'forgot password' link and login prompt
- add placeholder ForgotPassword page
- register forgot-password route

## Testing
- `npm run build` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_68796cf91a84832295bbda65d305213a