### PR TITLE
Configure axios baseURL from env and handle CSRF in login

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,12 +1,12 @@
 <script setup lang="ts">
-<<<<<<< HEAD  import DemoPage from './components/DemoPage.vue'
-  import Login from './pages/Login.vue'
-  import { useUserStore } from '@/stores/user'
-  import { useAuth } from '@/composables/useAuth'
+import DemoPage from './components/DemoPage.vue'
+import Login from './pages/Login.vue'
+import { useUserStore } from '@/stores/user'
+import { useAuth } from '@/composables/useAuth'
 
-  const userStore = useUserStore()
-  // Load authenticated user data if a valid token exists
-  useAuth()
+const userStore = useUserStore()
+// Load authenticated user data if a valid token exists
+useAuth()
 
 </script>
 
@@ -14,6 +14,5 @@
   <div class="flex flex-col items-center justify-center min-h-screen py-2">
     <img src="/logo.png" alt="">
     <component :is="userStore.user ? DemoPage : Login" />
-    <DemoPage  />
   </div>
 </template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,7 +7,7 @@ import { createPinia } from 'pinia'
 import router from './router'
 import axios from 'axios'
 
-axios.defaults.baseURL = 'http://localhost:5173'
+axios.defaults.baseURL = import.meta.env.VITE_API_URL
 axios.defaults.withCredentials = true
 
 const app = createApp(App)

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -54,6 +54,7 @@ import {
   CardFooter,
 } from '@/components/ui/card'
 import axios from 'axios'
+import { toast } from '@/components/ui/sonner'
 
 const email = ref('')
 const password = ref('')
@@ -62,12 +63,13 @@ const userStore = useUserStore()
 
 const login = async () => {
   try {
+    await axios.get('/sanctum/csrf-cookie')
     const { data } = await axios.post('/api/login', { email: email.value, password: password.value })
     axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
     userStore.setUser(data.user)
     router.push('/')
   } catch (e) {
-    alert('Invalid credentials')
+    toast.error('Invalid credentials')
   }
 }
 


### PR DESCRIPTION
## Summary
- configure axios to use `import.meta.env.VITE_API_URL`
- show error toast on invalid login and load CSRF cookie first
- clean up merge markers in `App.vue`

## Testing
- `npm install`
- `npm run dev`

------
https://chatgpt.com/codex/tasks/task_e_68797a242b548322be909213f626d864