### PR TITLE
Fix login screen and add auth pages

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,19 +1,13 @@
 <script setup lang="ts">
-  import DemoPage from './components/DemoPage.vue'
-  import Login from './pages/Login.vue'
-  import { useUserStore } from '@/stores/user'
-  import { useAuth } from '@/composables/useAuth'
+import { useAuth } from '@/composables/useAuth'
 
-  const userStore = useUserStore()
-  // Load authenticated user data if a valid token exists
-  useAuth()
+useAuth()
 
 </script>
 
 <template>
   <div class="flex flex-col items-center justify-center min-h-screen py-2">
-    <img src="/logo.png" alt="">
-    <component :is="userStore.user ? DemoPage : Login" />
-    <DemoPage  />
+    <img src="/logo.png" alt="" />
+    <router-view />
   </div>
 </template>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -7,7 +7,7 @@ import { createPinia } from 'pinia'
 import router from './router'
 import axios from 'axios'
 
-axios.defaults.baseURL = 'http://localhost:5173'
+axios.defaults.baseURL = import.meta.env.VITE_API_URL
 axios.defaults.withCredentials = true
 
 const app = createApp(App)

--- a/frontend/src/pages/ForgotPassword.vue
+++ b/frontend/src/pages/ForgotPassword.vue
@@ -1,0 +1,42 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-muted">
+    <Card class="mx-auto w-full max-w-md">
+      <form @submit.prevent="reset" class="space-y-6">
+        <CardHeader class="space-y-2 text-center">
+          <CardTitle>Forgot password</CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <Input v-model="email" placeholder="you@example.com" type="email" />
+        </CardContent>
+        <CardFooter class="flex flex-col space-y-4">
+          <Button type="submit" class="w-full">Send reset link</Button>
+          <p class="text-sm text-center text-muted-foreground">
+            <RouterLink to="/login" class="underline hover:text-primary">Back to login</RouterLink>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter, RouterLink } from 'vue-router'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+import axios from 'axios'
+
+const email = ref('')
+const router = useRouter()
+
+const reset = async () => {
+  try {
+    await axios.post('/api/forgot-password', { email: email.value })
+    alert('Check your email for reset instructions')
+    router.push('/login')
+  } catch (e) {
+    alert('Failed to send reset link')
+  }
+}
+</script>

--- a/frontend/src/pages/Login.vue
+++ b/frontend/src/pages/Login.vue
@@ -46,7 +46,6 @@ import {
   Card,
   CardHeader,
   CardTitle,
-  CardDescription,
   CardContent,
   CardFooter,
 } from '@/components/ui/card'

--- a/frontend/src/pages/Register.vue
+++ b/frontend/src/pages/Register.vue
@@ -1,0 +1,54 @@
+<template>
+  <div class="min-h-screen flex items-center justify-center bg-muted">
+    <Card class="mx-auto w-full max-w-md">
+      <form @submit.prevent="register" class="space-y-6">
+        <CardHeader class="space-y-2 text-center">
+          <CardTitle>Create an account</CardTitle>
+        </CardHeader>
+        <CardContent class="space-y-4">
+          <Input v-model="name" placeholder="Your name" />
+          <Input v-model="email" placeholder="you@example.com" type="email" />
+          <Input v-model="password" placeholder="••••••••" type="password" />
+        </CardContent>
+        <CardFooter class="flex flex-col space-y-4">
+          <Button type="submit" class="w-full">Sign up</Button>
+          <p class="text-sm text-center text-muted-foreground">
+            Already have an account?
+            <RouterLink to="/login" class="underline hover:text-primary">Log in</RouterLink>
+          </p>
+        </CardFooter>
+      </form>
+    </Card>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useRouter, RouterLink } from 'vue-router'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+import axios from 'axios'
+import { useUserStore } from '@/stores/user'
+
+const name = ref('')
+const email = ref('')
+const password = ref('')
+const router = useRouter()
+const userStore = useUserStore()
+
+const register = async () => {
+  try {
+    const { data } = await axios.post('/api/register', {
+      name: name.value,
+      email: email.value,
+      password: password.value,
+    })
+    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
+    userStore.setUser(data.user)
+    router.push('/')
+  } catch (e) {
+    alert('Registration failed')
+  }
+}
+</script>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,10 +1,14 @@
 import { createRouter, createWebHistory } from 'vue-router'
 import DemoPage from '@/components/DemoPage.vue'
 import Login from '@/pages/Login.vue'
+import Register from '@/pages/Register.vue'
+import ForgotPassword from '@/pages/ForgotPassword.vue'
 
 const routes = [
   { path: '/', component: DemoPage },
   { path: '/login', component: Login },
+  { path: '/register', component: Register },
+  { path: '/forgot-password', component: ForgotPassword },
 ]
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- hook up axios baseURL from env
- use `<router-view>` as main container
- implement login, register and forgot-password pages
- update routes

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a4e8a163883229c515dcf66979f35