### PR TITLE
Add header with auth modal

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,13 +1,15 @@
 <script setup lang="ts">
 import { useAuth } from '@/composables/useAuth'
+import Header from '@/components/Header.vue'
 
 useAuth()
-
 </script>
 
 <template>
-  <div class="flex flex-col items-center justify-center min-h-screen py-2">
-    <img src="/logo.png" alt="" />
-    <router-view />
+  <div class="min-h-screen flex flex-col">
+    <Header />
+    <main class="flex-1 p-4">
+      <router-view />
+    </main>
   </div>
 </template>

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,0 +1,33 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Icon } from '@iconify/vue'
+import { Dialog } from '@/components/ui/dialog'
+import { Button } from '@/components/ui/button'
+import LoginForm from '@/components/LoginForm.vue'
+import RegisterForm from '@/components/RegisterForm.vue'
+
+const mode = ref<'login' | 'register'>('login')
+</script>
+
+<template>
+  <header class="flex items-center justify-between px-6 py-4 border-b bg-background">
+    <RouterLink to="/" class="flex items-center">
+      <img src="/logo.png" alt="Logo" class="h-8" />
+    </RouterLink>
+
+    <Dialog>
+      <template #trigger>
+        <Button variant="ghost" class="p-2">
+          <Icon icon="lucide:user" class="w-6 h-6" />
+        </Button>
+      </template>
+      <template #title>
+        {{ mode === 'login' ? 'Log in' : 'Sign up' }}
+      </template>
+      <component
+        :is="mode === 'login' ? LoginForm : RegisterForm"
+        @switch="(m: 'login' | 'register') => (mode = m)"
+      />
+    </Dialog>
+  </header>
+</template>

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -1,0 +1,50 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import axios from 'axios'
+import { useUserStore } from '@/stores/user'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+
+const emit = defineEmits<{
+  (e: 'switch', mode: 'login' | 'register'): void
+}>()
+
+const email = ref('')
+const password = ref('')
+const userStore = useUserStore()
+
+const login = async () => {
+  try {
+    const { data } = await axios.post('/api/login', {
+      email: email.value,
+      password: password.value,
+    })
+    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
+    userStore.setUser(data.user)
+  } catch (e) {
+    alert('Invalid credentials')
+  }
+}
+</script>
+
+<template>
+  <Card class="mx-auto w-full max-w-md">
+    <form @submit.prevent="login" class="space-y-6">
+      <CardHeader class="space-y-2 text-center">
+        <CardTitle>Welcome back</CardTitle>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <Input v-model="email" placeholder="you@example.com" type="email" />
+        <Input v-model="password" placeholder="••••••••" type="password" />
+      </CardContent>
+      <CardFooter class="flex flex-col space-y-4">
+        <Button type="submit" class="w-full">Log in</Button>
+        <p class="text-sm text-center text-muted-foreground">
+          Don’t have an account?
+          <button type="button" class="underline hover:text-primary" @click="emit('switch', 'register')">Sign up</button>
+        </p>
+      </CardFooter>
+    </form>
+  </Card>
+</template>

--- a/frontend/src/components/RegisterForm.vue
+++ b/frontend/src/components/RegisterForm.vue
@@ -1,0 +1,53 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import axios from 'axios'
+import { useUserStore } from '@/stores/user'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+import { Card, CardHeader, CardTitle, CardContent, CardFooter } from '@/components/ui/card'
+
+const emit = defineEmits<{
+  (e: 'switch', mode: 'login' | 'register'): void
+}>()
+
+const name = ref('')
+const email = ref('')
+const password = ref('')
+const userStore = useUserStore()
+
+const register = async () => {
+  try {
+    const { data } = await axios.post('/api/register', {
+      name: name.value,
+      email: email.value,
+      password: password.value,
+    })
+    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
+    userStore.setUser(data.user)
+  } catch (e) {
+    alert('Registration failed')
+  }
+}
+</script>
+
+<template>
+  <Card class="mx-auto w-full max-w-md">
+    <form @submit.prevent="register" class="space-y-6">
+      <CardHeader class="space-y-2 text-center">
+        <CardTitle>Create an account</CardTitle>
+      </CardHeader>
+      <CardContent class="space-y-4">
+        <Input v-model="name" placeholder="Your name" />
+        <Input v-model="email" placeholder="you@example.com" type="email" />
+        <Input v-model="password" placeholder="••••••••" type="password" />
+      </CardContent>
+      <CardFooter class="flex flex-col space-y-4">
+        <Button type="submit" class="w-full">Sign up</Button>
+        <p class="text-sm text-center text-muted-foreground">
+          Already have an account?
+          <button type="button" class="underline hover:text-primary" @click="emit('switch', 'login')">Log in</button>
+        </p>
+      </CardFooter>
+    </form>
+  </Card>
+</template>


### PR DESCRIPTION
## Summary
- integrate global Header component
- implement login and registration forms for modal usage
- show Header and auth forms in App

## Testing
- `npm run build` *(fails: vue-tsc not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a515e3b448322a4a6dd07b54c6a11