### PR TITLE
Implement basic login flow

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1,15 +1,25 @@
 <script setup lang="ts">
+import { computed } from 'vue'
 import { useAuth } from '@/composables/useAuth'
+import { useUserStore } from '@/stores/user'
 import Header from '@/components/Header.vue'
+import Sidebar from '@/components/Sidebar.vue'
+import LoginPage from '@/components/LoginPage.vue'
 
 useAuth()
+const userStore = useUserStore()
+const isLoggedIn = computed(() => !!userStore.user)
 </script>
 
 <template>
-  <div class="min-h-screen flex flex-col">
-    <Header />
-    <main class="flex-1 p-4">
-      <router-view />
-    </main>
+  <LoginPage v-if="!isLoggedIn" />
+  <div v-else class="flex min-h-screen">
+    <Sidebar />
+    <div class="flex flex-1 flex-col">
+      <Header />
+      <main class="flex-1 p-4">
+        <router-view />
+      </main>
+    </div>
   </div>
 </template>

--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,40 +1,14 @@
 <script setup lang="ts">
-import { ref } from 'vue'
 import { Icon } from '@iconify/vue'
-import { Dialog } from '@/components/ui/dialog'
-import { Button } from '@/components/ui/button'
-import LoginForm from '@/components/LoginForm.vue'
-import RegisterForm from '@/components/RegisterForm.vue'
-import ForgotPasswordForm from '@/components/ForgotPasswordForm.vue'
-
-const mode = ref<'login' | 'register' | 'forgot'>('login')
 </script>
 
 <template>
   <header class="flex items-center justify-between px-6 py-4 border-b bg-background">
-    <RouterLink to="/" class="flex items-center">
+    <div class="flex items-center">
       <img src="/logo.png" alt="Logo" class="h-8" />
-    </RouterLink>
-
-    <Dialog>
-      <template #trigger>
-        <Button variant="ghost" class="p-2">
-          <Icon icon="lucide:user" class="w-6 h-6" />
-        </Button>
-      </template>
-      <template #title>
-        {{
-          mode === 'login'
-            ? 'Log in'
-            : mode === 'register'
-              ? 'Sign up'
-              : 'Forgot password'
-        }}
-      </template>
-      <component
-        :is="mode === 'login' ? LoginForm : mode === 'register' ? RegisterForm : ForgotPasswordForm"
-        @switch="(m: 'login' | 'register' | 'forgot') => (mode = m)"
-      />
-    </Dialog>
+    </div>
+    <button class="p-2">
+      <Icon icon="lucide:user" class="w-6 h-6" />
+    </button>
   </header>
 </template>

--- a/frontend/src/components/HelloWorldPage.vue
+++ b/frontend/src/components/HelloWorldPage.vue
@@ -1,0 +1,3 @@
+<template>
+  <div class="p-4">hello world</div>
+</template>

--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -12,9 +12,11 @@ const emit = defineEmits<{
 
 const email = ref('')
 const password = ref('')
+const error = ref<string | null>(null)
 const userStore = useUserStore()
 
 const login = async () => {
+  error.value = null
   try {
     const { data } = await axios.post('/api/login', {
       email: email.value,
@@ -22,8 +24,8 @@ const login = async () => {
     })
     axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
     userStore.setUser(data.user)
-  } catch (e) {
-    alert('Invalid credentials')
+  } catch (e: any) {
+    error.value = e.response?.data?.message || 'Invalid credentials'
   }
 }
 </script>
@@ -37,6 +39,7 @@ const login = async () => {
       <CardContent class="space-y-4">
         <Input v-model="email" placeholder="you@example.com" type="email" />
         <Input v-model="password" placeholder="••••••••" type="password" />
+        <p v-if="error" class="text-sm text-red-500">{{ error }}</p>
       </CardContent>
       <CardFooter class="flex flex-col space-y-4">
         <div class="w-full text-right">

--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -1,0 +1,41 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import axios from 'axios'
+import { useUserStore } from '@/stores/user'
+import { useRouter } from 'vue-router'
+import { Input } from '@/components/ui/input'
+import { Button } from '@/components/ui/button'
+
+const email = ref('')
+const password = ref('')
+const error = ref<string | null>(null)
+const userStore = useUserStore()
+const router = useRouter()
+
+async function login() {
+  error.value = null
+  try {
+    const { data } = await axios.post('/api/login', {
+      email: email.value,
+      password: password.value,
+    })
+    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
+    userStore.setUser(data.user)
+    router.push('/')
+  } catch (e: any) {
+    error.value = e.response?.data?.message || 'Invalid credentials'
+  }
+}
+</script>
+
+<template>
+  <div class="min-h-screen flex flex-col items-center justify-center space-y-8">
+    <img src="/logo.png" alt="Logo" class="h-16" />
+    <form @submit.prevent="login" class="w-full max-w-sm space-y-4">
+      <Input v-model="email" type="email" placeholder="Email" />
+      <Input v-model="password" type="password" placeholder="Password" />
+      <p v-if="error" class="text-red-500 text-sm">{{ error }}</p>
+      <Button type="submit" class="w-full">Log in</Button>
+    </form>
+  </div>
+</template>

--- a/frontend/src/components/Sidebar.vue
+++ b/frontend/src/components/Sidebar.vue
@@ -1,0 +1,72 @@
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Icon } from '@iconify/vue'
+
+interface MenuItem {
+  label: string
+  icon: string
+  children?: MenuItem[]
+}
+
+const menuData: MenuItem[] = [
+  {
+    label: 'Inventory',
+    icon: 'mdi:warehouse',
+    children: [
+      { label: 'Products', icon: 'mdi:package-variant' },
+      { label: 'Stocktake', icon: 'mdi:clipboard-list-outline' },
+    ],
+  },
+  {
+    label: 'Sales',
+    icon: 'mdi:cart-outline',
+    children: [
+      { label: 'Orders', icon: 'mdi:format-list-bulleted' },
+      { label: 'Customers', icon: 'mdi:account-outline' },
+    ],
+  },
+]
+
+const collapsed = ref(false)
+const open = ref<Record<number, boolean>>({})
+
+function toggleItem(idx: number) {
+  open.value[idx] = !open.value[idx]
+}
+</script>
+
+<template>
+  <aside :class="['h-screen border-r bg-muted transition-all duration-300', collapsed ? 'w-16' : 'w-60']">
+    <div class="flex items-center justify-between p-2">
+      <span v-if="!collapsed" class="font-bold">Menu</span>
+      <button @click="collapsed = !collapsed" class="p-1">
+        <Icon :icon="collapsed ? 'radix-icons:chevron-right' : 'radix-icons:chevron-left'" class="h-5 w-5" />
+      </button>
+    </div>
+    <nav class="mt-2 space-y-1">
+      <div v-for="(item, idx) in menuData" :key="item.label" class="px-1">
+        <button
+          @click="toggleItem(idx)"
+          class="flex w-full items-center gap-2 rounded px-2 py-2 text-left hover:bg-accent"
+          :class="open[idx] && !collapsed ? 'bg-accent' : ''"
+        >
+          <Icon :icon="item.icon" class="h-5 w-5" />
+          <span v-if="!collapsed" class="flex-1">{{ item.label }}</span>
+          <Icon
+            v-if="!collapsed && item.children"
+            :icon="open[idx] ? 'radix-icons:chevron-down' : 'radix-icons:chevron-right'"
+            class="h-4 w-4"
+          />
+        </button>
+        <ul v-if="!collapsed && item.children && open[idx]" class="ml-6 mt-1 space-y-1">
+          <li v-for="child in item.children" :key="child.label">
+            <a href="#" class="flex items-center gap-2 rounded px-2 py-1 text-sm hover:bg-accent">
+              <Icon :icon="child.icon" class="h-4 w-4" />
+              <span>{{ child.label }}</span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </nav>
+  </aside>
+</template>

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -1,7 +1,8 @@
 import { createRouter, createWebHistory } from 'vue-router'
-import DemoPage from '@/components/DemoPage.vue'
+import HelloWorldPage from '@/components/HelloWorldPage.vue'
+
 const routes = [
-  { path: '/', component: DemoPage },
+  { path: '/', component: HelloWorldPage },
 ]
 
 const router = createRouter({


### PR DESCRIPTION
## Summary
- add simple login page component
- add sidebar component and restructure layout
- update header for logged-in layout
- show login page if user is not authenticated
- route to a Hello World page
- display login errors in login forms

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687a6cce99908322b662b105c0e8d8c1