### PR TITLE
Implement password reset API endpoint

### DIFF
--- a/backend/app/Http/Controllers/PasswordResetController.php
+++ b/backend/app/Http/Controllers/PasswordResetController.php
@@ -1,0 +1,25 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Password;
+
+class PasswordResetController extends Controller
+{
+    public function sendResetLink(Request $request): JsonResponse
+    {
+        $request->validate([
+            'email' => 'required|email',
+        ]);
+
+        $status = Password::sendResetLink(
+            $request->only('email')
+        );
+
+        return $status === Password::RESET_LINK_SENT
+            ? response()->json(['status' => __($status)])
+            : response()->json(['message' => __($status)], 422);
+    }
+}

--- a/backend/database/migrations/0001_01_01_000003_create_password_reset_tokens_table.php
+++ b/backend/database/migrations/0001_01_01_000003_create_password_reset_tokens_table.php
@@ -1,0 +1,21 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration {
+    public function up(): void
+    {
+        Schema::create('password_reset_tokens', function (Blueprint $table) {
+            $table->string('email')->index();
+            $table->string('token');
+            $table->timestamp('created_at')->nullable();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('password_reset_tokens');
+    }
+};

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -3,12 +3,14 @@
 
 use Illuminate\Support\Facades\Route;
 use App\Http\Controllers\AuthController;
+use App\Http\Controllers\PasswordResetController;
 
 Route::get('/ping', function () {
     return response()->json(['message' => 'pong']);
 });
 
 Route::post('/login', [AuthController::class, 'login']);
+Route::post('/forgot-password', [PasswordResetController::class, 'sendResetLink']);
 Route::middleware('auth:sanctum')->group(function () {
     Route::post('/logout', [AuthController::class, 'logout']);
     Route::get('/user', [AuthController::class, 'user']);

--- a/backend/tests/Feature/ForgotPasswordTest.php
+++ b/backend/tests/Feature/ForgotPasswordTest.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Tests\TestCase;
+
+class ForgotPasswordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_endpoint_returns_success_for_valid_email(): void
+    {
+        $user = User::factory()->create();
+
+        config(['app.key' => 'base64:'.base64_encode(random_bytes(32))]);
+
+        ResetPassword::createUrlUsing(fn ($user, string $token) => 'http://example.com/reset/'.$token);
+
+        $response = $this->postJson('/api/forgot-password', [
+            'email' => $user->email,
+        ]);
+
+        $response->assertOk()->assertJsonStructure(['status']);
+    }
+}


### PR DESCRIPTION
## Summary
- add `PasswordResetController` for sending reset links
- define `/api/forgot-password` route
- migrate password reset tokens table
- test password reset link request

## Testing
- `vendor/bin/phpunit`

------
https://chatgpt.com/codex/tasks/task_e_687a70aa68a08322aef4e14509ebb9b3