### PR TITLE
Add authentication feature tests

### DIFF
--- a/backend/tests/Feature/ForgotPasswordTest.php
+++ b/backend/tests/Feature/ForgotPasswordTest.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Auth\Notifications\ResetPassword;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Notification;
+use Tests\TestCase;
+
+class ForgotPasswordTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Ensure /api/forgot-password sends a reset link for existing users.
+     */
+    public function test_forgot_password_sends_reset_link_to_existing_user(): void
+    {
+        Notification::fake();
+
+        $user = User::factory()->create();
+
+        $response = $this->postJson('/api/forgot-password', [
+            'email' => $user->email,
+        ]);
+
+        $response->assertStatus(200);
+
+        Notification::assertSentTo($user, ResetPassword::class);
+    }
+
+    /**
+     * Ensure /api/forgot-password returns errors for non-existent users.
+     */
+    public function test_forgot_password_returns_error_for_unknown_email(): void
+    {
+        Notification::fake();
+
+        $response = $this->postJson('/api/forgot-password', [
+            'email' => 'unknown@example.com',
+        ]);
+
+        $response->assertStatus(422);
+    }
+}

--- a/backend/tests/Feature/LoginTest.php
+++ b/backend/tests/Feature/LoginTest.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Hash;
+use Tests\TestCase;
+
+class LoginTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * Ensure /api/login authenticates with valid credentials.
+     */
+    public function test_login_endpoint_authenticates_with_valid_credentials(): void
+    {
+        $user = User::factory()->create([
+            'password' => Hash::make('secret'),
+        ]);
+
+        $response = $this->postJson('/api/login', [
+            'email' => $user->email,
+            'password' => 'secret',
+        ]);
+
+        $response->assertOk()
+                 ->assertJsonStructure([
+                     'token',
+                     'user' => ['id', 'email'],
+                 ]);
+    }
+}


### PR DESCRIPTION
## Summary
- add tests for `/api/login`
- add tests for `/api/forgot-password`

## Testing
- `php vendor/bin/phpunit tests/Feature/LoginTest.php tests/Feature/ForgotPasswordTest.php --testdox` *(fails: 3 failures)*

------
https://chatgpt.com/codex/tasks/task_e_687a70b2f90c832288c8969cfd59daee