### PR TITLE
Fix missing EncryptCookies middleware

### DIFF
--- a/backend/app/Http/Middleware/EncryptCookies.php
+++ b/backend/app/Http/Middleware/EncryptCookies.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Illuminate\Cookie\Middleware\EncryptCookies as Middleware;
+
+class EncryptCookies extends Middleware
+{
+    // No additional functionality needed.
+}


### PR DESCRIPTION
## Summary
- implement `EncryptCookies` middleware as a wrapper around `Illuminate\Cookie\Middleware\EncryptCookies`

## Testing
- `php artisan test` *(fails: Class "Illuminate\Foundation\Application" not found)*

------
https://chatgpt.com/codex/tasks/task_e_687a7f8043e48322a64084597023986c