### PR TITLE
Implement logout action and connect to header

### DIFF
--- a/frontend/src/components/Header.vue
+++ b/frontend/src/components/Header.vue
@@ -1,5 +1,17 @@
 <script setup lang="ts">
 import { Icon } from '@iconify/vue'
+import { useUserStore } from '@/stores/user'
+import {
+  DropdownMenu,
+  DropdownMenuTrigger,
+  DropdownMenuContent,
+  DropdownMenuItem,
+} from '@/components/ui/dropdown-menu'
+
+const userStore = useUserStore()
+function logout() {
+  userStore.logout()
+}
 </script>
 
 <template>
@@ -7,8 +19,15 @@ import { Icon } from '@iconify/vue'
     <div class="flex items-center">
       <img src="/logo.png" alt="Logo" class="h-8" />
     </div>
-    <button class="p-2">
-      <Icon icon="lucide:user" class="w-6 h-6" />
-    </button>
+    <DropdownMenu>
+      <DropdownMenuTrigger as-child>
+        <button class="p-2">
+          <Icon icon="lucide:user" class="w-6 h-6" />
+        </button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem @select="logout">Logout</DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
   </header>
 </template>

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -1,5 +1,6 @@
 import { defineStore } from 'pinia'
 import axios from 'axios'
+import router from '@/router'
 
 export const useUserStore = defineStore('user', {
     state: () => ({
@@ -9,10 +10,12 @@ export const useUserStore = defineStore('user', {
         setUser(user: any) {
             this.user = user
         },
-        logout() {
+        async logout() {
+            await axios.post('/api/logout')
             this.user = null
             localStorage.removeItem('token')
             delete axios.defaults.headers.common.Authorization
+            router.push('/login')
         },
     },
 })


### PR DESCRIPTION
## Summary
- extend `logout` store action to hit `/api/logout` and redirect
- create user dropdown in `Header.vue` and call the logout action

## Testing
- `npm run lint:fix` *(fails: ESLint couldn't find plugin and various errors)*
- `composer test` *(fails: some feature tests fail)*

------
https://chatgpt.com/codex/tasks/task_e_687a837f94908322a84fbdafd3366fe2