### PR TITLE
Switch login/logout to session auth

### DIFF
--- a/backend/app/Http/Controllers/AuthController.php
+++ b/backend/app/Http/Controllers/AuthController.php
@@ -15,22 +15,23 @@ class AuthController extends Controller
             'password' => 'required',
         ]);
 
-        if (!Auth::attempt($credentials)) {
+        if (!Auth::guard('web')->attempt($credentials)) {
             return response()->json(['message' => 'Unauthorized'], 401);
         }
 
-        $user = Auth::user();
-        $token = $user->createToken('auth-token')->plainTextToken;
+        $request->session()->regenerate();
 
         return response()->json([
-            'token' => $token,
-            'user' => $user,
+            'user' => $request->user(),
         ]);
     }
 
     public function logout(Request $request): JsonResponse
     {
-        $request->user()->currentAccessToken()->delete();
+        Auth::guard('web')->logout();
+
+        $request->session()->invalidate();
+        $request->session()->regenerateToken();
 
         return response()->json(['message' => 'Logged out']);
     }

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -9,9 +9,9 @@ Route::get('/ping', function () {
     return response()->json(['message' => 'pong']);
 });
 
-Route::post('/login', [AuthController::class, 'login']);
-Route::post('/forgot-password', [PasswordResetController::class, 'sendResetLink']);
-Route::middleware('auth:sanctum')->group(function () {
-    Route::post('/logout', [AuthController::class, 'logout']);
-    Route::get('/user', [AuthController::class, 'user']);
+Route::middleware('web')->group(function () {
+    Route::post('/login', [AuthController::class, 'login']);
+    Route::post('/logout', [AuthController::class, 'logout'])->middleware('auth');
+    Route::get('/user', [AuthController::class, 'user'])->middleware('auth');
 });
+Route::post('/forgot-password', [PasswordResetController::class, 'sendResetLink']);

--- a/backend/tests/Feature/LoginTest.php
+++ b/backend/tests/Feature/LoginTest.php
@@ -27,7 +27,6 @@ class LoginTest extends TestCase
 
         $response->assertOk()
                  ->assertJsonStructure([
-                     'token',
                      'user' => ['id', 'email'],
                  ]);
     }


### PR DESCRIPTION
## Summary
- switch login/logout to the web session guard
- return the authenticated user after login
- update API routes to use the web middleware and auth
- adjust LoginTest for new response shape

## Testing
- `composer test`

------
https://chatgpt.com/codex/tasks/task_e_687a838d53f88322af9103b114273137