### PR TITLE
Document CSRF cookie step

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,7 @@ To support cross-domain authentication:
 
 - Make sure `SANCTUM_STATEFUL_DOMAINS` includes the frontend domain (e.g., `morkovka-frontend.ddev.site:5173`)
 - CORS settings in `config/cors.php` must allow the origin
+- The frontend must call `/sanctum/csrf-cookie` before attempting to log in so that Laravel sets the CSRF token cookie
 
 ---
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -8,3 +8,9 @@ DB_PORT=5432
 DB_DATABASE=morkovka
 DB_USERNAME=postgres
 DB_PASSWORD=secret
+
+# URL of the SPA frontend
+FRONTEND_URL=http://localhost:5173
+
+# Domains that should receive stateful API cookies
+SANCTUM_STATEFUL_DOMAINS=localhost:5173


### PR DESCRIPTION
## Summary
- mention hitting `/sanctum/csrf-cookie` before login
- ensure example env file has `FRONTEND_URL` and `SANCTUM_STATEFUL_DOMAINS`

## Testing
- `php artisan test` *(fails: Method Illuminate\Auth\RequestGuard::attempt does not exist)*

------
https://chatgpt.com/codex/tasks/task_e_687a83949130832290fb3e2664efb747