### PR TITLE
Switch to Sanctum cookie auth

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -18,11 +18,11 @@ const userStore = useUserStore()
 const login = async () => {
   error.value = null
   try {
+    await axios.get('/sanctum/csrf-cookie')
     const { data } = await axios.post('/api/login', {
       email: email.value,
       password: password.value,
     })
-    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
     userStore.setUser(data.user)
   } catch (e: any) {
     error.value = e.response?.data?.message || 'Invalid credentials'
@@ -32,7 +32,7 @@ const login = async () => {
 
 <template>
   <Card class="mx-auto w-full max-w-md">
-    <form @submit.prevent="login" class="space-y-6">
+    <form class="space-y-6" @submit.prevent="login">
       <CardHeader class="space-y-2 text-center">
         <CardTitle>Welcome back</CardTitle>
       </CardHeader>

--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -26,12 +26,11 @@ watch(
 async function login() {
   error.value = null
   try {
+    await axios.get('/sanctum/csrf-cookie')
     const { data } = await axios.post('/api/login', {
       email: email.value,
       password: password.value,
     })
-    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
-    localStorage.setItem('token', data.token)
     userStore.setUser(data.user)
     router.push('/dashboard')
   } catch (e: any) {

--- a/frontend/src/components/RegisterForm.vue
+++ b/frontend/src/components/RegisterForm.vue
@@ -17,13 +17,12 @@ const userStore = useUserStore()
 
 const register = async () => {
   try {
+    await axios.get('/sanctum/csrf-cookie')
     const { data } = await axios.post('/api/register', {
       name: name.value,
       email: email.value,
       password: password.value,
     })
-    axios.defaults.headers.common.Authorization = `Bearer ${data.token}`
-    localStorage.setItem('token', data.token)
     userStore.setUser(data.user)
   } catch (e) {
     alert('Registration failed')
@@ -33,7 +32,7 @@ const register = async () => {
 
 <template>
   <Card class="mx-auto w-full max-w-md">
-    <form @submit.prevent="register" class="space-y-6">
+    <form class="space-y-6" @submit.prevent="register">
       <CardHeader class="space-y-2 text-center">
         <CardTitle>Create an account</CardTitle>
       </CardHeader>

--- a/frontend/src/main.ts
+++ b/frontend/src/main.ts
@@ -10,10 +10,6 @@ import axios from 'axios'
 axios.defaults.baseURL = import.meta.env.VITE_API_BASE_URL
 axios.defaults.withCredentials = true
 
-const storedToken = localStorage.getItem('token')
-if (storedToken) {
-    axios.defaults.headers.common.Authorization = `Bearer ${storedToken}`
-}
 
 const app = createApp(App)
 app.use(createPinia())

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -14,7 +14,6 @@ export const useUserStore = defineStore('user', {
             await axios.post('/api/logout')
             this.user = null
             localStorage.removeItem('token')
-            delete axios.defaults.headers.common.Authorization
             router.push('/login')
         },
     },


### PR DESCRIPTION
## Summary
- remove token handling from login and register components
- drop token retrieval on app bootstrap
- simplify logout store

## Testing
- `npm run lint:fix` *(fails: 22 errors, 4 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_687b6514289483229fe6607ca84b431d