### PR TITLE
Ensure Sanctum CSRF cookie fetched before login

### DIFF
--- a/frontend/src/components/LoginForm.vue
+++ b/frontend/src/components/LoginForm.vue
@@ -18,6 +18,7 @@ const userStore = useUserStore()
 const login = async () => {
   error.value = null
   try {
+    await axios.get('/sanctum/csrf-cookie')
     const { data } = await axios.post('/api/login', {
       email: email.value,
       password: password.value,
@@ -32,7 +33,7 @@ const login = async () => {
 
 <template>
   <Card class="mx-auto w-full max-w-md">
-    <form @submit.prevent="login" class="space-y-6">
+    <form class="space-y-6" @submit.prevent="login">
       <CardHeader class="space-y-2 text-center">
         <CardTitle>Welcome back</CardTitle>
       </CardHeader>

--- a/frontend/src/components/LoginPage.vue
+++ b/frontend/src/components/LoginPage.vue
@@ -26,6 +26,7 @@ watch(
 async function login() {
   error.value = null
   try {
+    await axios.get('/sanctum/csrf-cookie')
     const { data } = await axios.post('/api/login', {
       email: email.value,
       password: password.value,


### PR DESCRIPTION
## Summary
- acquire Sanctum CSRF cookie before posting to `/api/login`
- leave axios with credentials enabled in `main.ts`

## Testing
- `npm run lint:fix` *(fails: various lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_687b651b3f708322afc0dd781fc98d64