### PR TITLE
Fix auth composable user response

### DIFF
--- a/frontend/src/composables/useAuth.ts
+++ b/frontend/src/composables/useAuth.ts
@@ -1,12 +1,12 @@
 import { useQuery } from '@tanstack/vue-query'
 import { watchEffect } from 'vue'
 import axios from 'axios'
-import { useUserStore } from '@/stores/user'
+import { useUserStore, type User } from '@/stores/user'
 
 export function useAuth() {
   const userStore = useUserStore()
 
-  const query = useQuery<{ id: number; name: string; email: string }>({
+  const query = useQuery<{ user: User }>({
     queryKey: ['user'],
     queryFn: async () => {
       const { data } = await axios.get('/api/user')
@@ -17,7 +17,7 @@ export function useAuth() {
 
   watchEffect(() => {
     if (query.data.value) {
-      userStore.setUser(query.data.value)
+      userStore.setUser(query.data.value.user)
     }
     if (query.error.value) {
       userStore.logout()

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -2,12 +2,18 @@ import { defineStore } from 'pinia'
 import axios from 'axios'
 import router from '@/router'
 
+export interface User {
+    id: number
+    name: string
+    email: string
+}
+
 export const useUserStore = defineStore('user', {
     state: () => ({
-        user: null as null | { id: number; name: string; email: string },
+        user: null as null | User,
     }),
     actions: {
-        setUser(user: any) {
+        setUser(user: User) {
             this.user = user
         },
         async logout() {


### PR DESCRIPTION
## Summary
- use `query.data.value.user` when hydrating the user store
- type-check API response as `{ user: User }`
- define a `User` interface and update the store typings

## Testing
- `npm run lint:fix` *(fails: many lint errors)*
- `php artisan test` *(fails: No application encryption key)*

------
https://chatgpt.com/codex/tasks/task_e_687b652070c4832293f9a9ac0051b719