### PR TITLE
Fix logout error handling

### DIFF
--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -11,7 +11,14 @@ export const useUserStore = defineStore('user', {
             this.user = user
         },
         async logout() {
-            await axios.post('/api/logout')
+            try {
+                await axios.post('/api/logout')
+            } catch (error: any) {
+                const status = error?.response?.status
+                if (status !== 401 && status !== 419) {
+                    throw error
+                }
+            }
             this.user = null
             localStorage.removeItem('token')
             delete axios.defaults.headers.common.Authorization


### PR DESCRIPTION
## Summary
- ignore 401/419 responses when logging out

## Testing
- `npm run build` *(fails: TS1005 in Header.vue)*
- `composer test` *(fails: No application encryption key specified)*

------
https://chatgpt.com/codex/tasks/task_e_687b652a3f40832282af445f66b30794